### PR TITLE
Add missing semicolons

### DIFF
--- a/vendor/assets/stylesheets/index.scss
+++ b/vendor/assets/stylesheets/index.scss
@@ -1,1 +1,1 @@
-@import 'normalize-rails/normalize'
+@import 'normalize-rails/normalize';

--- a/vendor/assets/stylesheets/normalize-rails.scss
+++ b/vendor/assets/stylesheets/normalize-rails.scss
@@ -1,1 +1,1 @@
-@import 'normalize-rails/normalize'
+@import 'normalize-rails/normalize';


### PR DESCRIPTION
While the regular sass is fine without them, sassc-rails which uses
libsass isn't.
